### PR TITLE
Improve mobile responsiveness of locations table

### DIFF
--- a/client/src/App.css
+++ b/client/src/App.css
@@ -155,7 +155,9 @@ body {
 .table-wrapper {
   border: 1px solid #e2e8f0;
   border-radius: 0.75rem;
-  overflow: hidden;
+  overflow-x: auto;
+  overflow-y: hidden;
+  padding: 0.75rem;
 }
 
 table {
@@ -230,4 +232,79 @@ a {
 
 a:hover {
   text-decoration: underline;
+}
+
+@media (max-width: 640px) {
+  .dashboard {
+    gap: 1rem;
+  }
+
+  .table-wrapper {
+    padding: 1rem;
+  }
+
+  table {
+    border-collapse: separate;
+    width: 100%;
+  }
+
+  thead {
+    display: none;
+  }
+
+  tbody {
+    display: flex;
+    flex-direction: column;
+    gap: 1rem;
+  }
+
+  tbody tr {
+    display: grid;
+    gap: 0.75rem;
+    padding: 1rem;
+    border: 1px solid #e2e8f0;
+    border-radius: 0.85rem;
+    background: #ffffff;
+    box-shadow: 0 15px 30px -25px rgba(15, 23, 42, 0.6);
+    transition: box-shadow 0.2s ease, transform 0.2s ease;
+  }
+
+  tbody tr:hover {
+    background: #f8fbff;
+    box-shadow: 0 15px 30px -20px rgba(37, 99, 235, 0.4);
+    transform: translateY(-1px);
+  }
+
+  tbody tr.selected {
+    box-shadow: 0 0 0 2px rgba(37, 99, 235, 0.35);
+    background: #eff6ff;
+  }
+
+  tbody tr td {
+    display: grid;
+    grid-template-columns: minmax(110px, max-content) 1fr;
+    gap: 0.5rem;
+    align-items: start;
+    padding: 0;
+    border: none;
+  }
+
+  tbody tr td::before {
+    content: attr(data-label);
+    font-size: 0.75rem;
+    font-weight: 600;
+    letter-spacing: 0.05em;
+    text-transform: uppercase;
+    color: #64748b;
+  }
+
+  tbody tr td.empty {
+    display: block;
+    text-align: center;
+    padding: 1.5rem 0;
+  }
+
+  tbody tr td.empty::before {
+    content: none;
+  }
 }

--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -166,11 +166,11 @@ function App() {
                     className={location.id === selectedLocationId ? 'selected' : ''}
                     onClick={() => setSelectedLocationId(location.id)}
                   >
-                    <td>{location.name || '—'}</td>
-                    <td>{location.email || '—'}</td>
-                    <td>{location.phone || '—'}</td>
-                    <td>{location.city || '—'}</td>
-                    <td>{location.state || '—'}</td>
+                    <td data-label="Name">{location.name || '—'}</td>
+                    <td data-label="Email">{location.email || '—'}</td>
+                    <td data-label="Phone">{location.phone || '—'}</td>
+                    <td data-label="City">{location.city || '—'}</td>
+                    <td data-label="State">{location.state || '—'}</td>
                   </tr>
                 ))}
               </tbody>


### PR DESCRIPTION
## Summary
- add horizontal scrolling padding and mobile card layout for the locations table
- add data labels on table cells to support responsive card styling

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d9e9349880832e8b4c88dfb6428d88