### PR TITLE
Add shimmer skeleton overlays for dashboard panels

### DIFF
--- a/client/src/App.css
+++ b/client/src/App.css
@@ -125,6 +125,7 @@ body {
   display: flex;
   flex-direction: column;
   gap: 1rem;
+  position: relative;
 }
 
 .panel-header {
@@ -156,6 +157,7 @@ body {
   border: 1px solid #e2e8f0;
   border-radius: 0.75rem;
   overflow: hidden;
+  position: relative;
 }
 
 table {
@@ -230,4 +232,132 @@ a {
 
 a:hover {
   text-decoration: underline;
+}
+
+.skeleton-overlay {
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(135deg, rgba(241, 245, 249, 0.8), rgba(226, 232, 240, 0.72));
+  display: flex;
+  align-items: stretch;
+  justify-content: center;
+  padding: 1rem;
+  pointer-events: none;
+  backdrop-filter: blur(2px);
+  z-index: 2;
+}
+
+.skeleton-overlay::after {
+  content: '';
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(90deg, rgba(255, 255, 255, 0) 0%, rgba(255, 255, 255, 0.7) 50%, rgba(255, 255, 255, 0) 100%);
+  transform: translateX(-100%);
+  animation: shimmer 1.6s infinite;
+}
+
+.skeleton-overlay > * {
+  position: relative;
+  z-index: 1;
+}
+
+@keyframes shimmer {
+  0% {
+    transform: translateX(-100%);
+  }
+  100% {
+    transform: translateX(100%);
+  }
+}
+
+
+.table-skeleton {
+  align-items: flex-start;
+  background: none;
+}
+
+.skeleton-table {
+  position: relative;
+  width: 100%;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.skeleton-row {
+  display: grid;
+  grid-template-columns: 2.4fr 2.2fr 1.3fr 1.1fr 0.9fr;
+  gap: 1rem;
+}
+
+.skeleton-cell,
+.skeleton-label,
+.skeleton-value {
+  display: block;
+  height: 0.95rem;
+  border-radius: 999px;
+  background: linear-gradient(90deg, #e2e8f0 0%, #f1f5f9 50%, #e2e8f0 100%);
+  background-size: 200% 100%;
+  animation: pulse 1.8s ease-in-out infinite;
+}
+
+.skeleton-row .skeleton-cell:nth-child(1) {
+  width: 85%;
+}
+
+.skeleton-row .skeleton-cell:nth-child(2) {
+  width: 70%;
+}
+
+.skeleton-row .skeleton-cell:nth-child(3) {
+  width: 60%;
+}
+
+.skeleton-row .skeleton-cell:nth-child(4) {
+  width: 65%;
+}
+
+.skeleton-row .skeleton-cell:nth-child(5) {
+  width: 55%;
+}
+
+@keyframes pulse {
+  0%,
+  100% {
+    opacity: 0.6;
+    background-position: 0% 0;
+  }
+  50% {
+    opacity: 1;
+    background-position: 100% 0;
+  }
+}
+
+.detail-skeleton {
+  align-items: flex-start;
+}
+
+.skeleton-card-grid {
+  position: relative;
+  display: grid;
+  gap: 1.25rem;
+  width: 100%;
+  grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+}
+
+.skeleton-field {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.skeleton-label {
+  height: 0.75rem;
+  width: 35%;
+  opacity: 0.75;
+}
+
+.skeleton-value {
+  height: 1.05rem;
+  width: 80%;
 }

--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -1,4 +1,6 @@
 import { useEffect, useMemo, useState } from 'react';
+import LocationDetailSkeleton from './components/LocationDetailSkeleton';
+import LocationTableSkeleton from './components/LocationTableSkeleton';
 import './App.css';
 
 const PAGE_SIZE = 100;
@@ -142,6 +144,7 @@ function App() {
             {error && <span className="status-badge error">{error}</span>}
           </div>
           <div className="table-wrapper">
+            {isLoading && <LocationTableSkeleton />}
             <table>
               <thead>
                 <tr>
@@ -185,7 +188,7 @@ function App() {
             {detailsError && <span className="status-badge error">{detailsError}</span>}
           </div>
           {!selectedLocationId && <p className="placeholder">Select a location to inspect its profile.</p>}
-          {selectedLocationId && !detailsLoading && !detailsError && locationDetails && (
+          {selectedLocationId && !detailsError && locationDetails && (
             <dl className="details-grid">
               <div>
                 <dt>Name</dt>
@@ -237,6 +240,7 @@ function App() {
               </div>
             </dl>
           )}
+          {selectedLocationId && detailsLoading && <LocationDetailSkeleton />}
         </section>
       </main>
     </div>

--- a/client/src/components/LocationDetailSkeleton.jsx
+++ b/client/src/components/LocationDetailSkeleton.jsx
@@ -1,0 +1,28 @@
+const FIELDS = [
+  'Name',
+  'Email',
+  'Phone',
+  'Website',
+  'Address',
+  'Created',
+  'Updated',
+  'Time zone',
+  'Status',
+];
+
+const LocationDetailSkeleton = () => {
+  return (
+    <div className="skeleton-overlay detail-skeleton" aria-hidden="true">
+      <div className="skeleton-card-grid">
+        {FIELDS.map((label) => (
+          <div key={label} className="skeleton-field">
+            <span className="skeleton-label" />
+            <span className="skeleton-value" />
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+};
+
+export default LocationDetailSkeleton;

--- a/client/src/components/LocationTableSkeleton.jsx
+++ b/client/src/components/LocationTableSkeleton.jsx
@@ -1,0 +1,19 @@
+const COLUMN_COUNT = 5;
+
+const LocationTableSkeleton = ({ rows = 8 }) => {
+  return (
+    <div className="skeleton-overlay table-skeleton" aria-hidden="true">
+      <div className="skeleton-table">
+        {Array.from({ length: rows }).map((_, rowIndex) => (
+          <div key={rowIndex} className="skeleton-row">
+            {Array.from({ length: COLUMN_COUNT }).map((_, colIndex) => (
+              <span key={colIndex} className="skeleton-cell" />
+            ))}
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+};
+
+export default LocationTableSkeleton;


### PR DESCRIPTION
## Summary
- add lightweight skeleton components for the locations table and detail views
- render the skeleton overlays during list and detail loading without unmounting the existing data
- style the shimmer loading experience to match a contemporary dashboard look

## Testing
- npm run dev -- --host 0.0.0.0 --port 4173

------
https://chatgpt.com/codex/tasks/task_e_68d9e9377cc0832e8dbc419ed47326aa